### PR TITLE
Adding support for cloud formation capabilities.

### DIFF
--- a/lib/awscloudformation.litcoffee
+++ b/lib/awscloudformation.litcoffee
@@ -177,7 +177,7 @@ This example uses the output from the `processTemplate` to feed the `createStack
 						niteoawsCF.validateTemplate(content)
 							.then =>
 								grunt.log.ok "Template Validated."
-								niteoawsCF.createStack(@data.name, content, @data.parameters)
+								niteoawsCF.createStack(@data.name, content, @data.parameters, @data.capabilities)
 							.then =>
 								grunt.log.ok "Successfully created stack #{@data.name}"
 				.then =>

--- a/lib/awscloudformation.litcoffee
+++ b/lib/awscloudformation.litcoffee
@@ -288,7 +288,7 @@ This example uses the output from the `processTemplate` to feed the `updateStack
 						grunt.log.ok "Successfully retreived the stack metadata and placed it into grunt.option(#{@data.outputKey})"
 						done()
 					, (err) ->
-						if err.message == "No updates are to be performed." then grunt.log.info err else grunt.fail.fatal err
+						if err.message == "No updates are to be performed." then grunt.log.writeln err else grunt.fail.fatal err
 						done()
 					, (progress) ->
 						grunt.log.writeln "#{moment().format()}: #{progress}"['gray']

--- a/lib/awscloudformation.litcoffee
+++ b/lib/awscloudformation.litcoffee
@@ -288,7 +288,7 @@ This example uses the output from the `processTemplate` to feed the `updateStack
 						grunt.log.ok "Successfully retreived the stack metadata and placed it into grunt.option(#{@data.outputKey})"
 						done()
 					, (err) ->
-						if err.message == "No updates are to be performed." then grunt.log.warn err else grunt.fail.fatal err
+						if err.message == "No updates are to be performed." then grunt.log.info err else grunt.fail.fatal err
 						done()
 					, (progress) ->
 						grunt.log.writeln "#{moment().format()}: #{progress}"['gray']

--- a/lib/awscloudformation.litcoffee
+++ b/lib/awscloudformation.litcoffee
@@ -258,7 +258,7 @@ This example uses the output from the `processTemplate` to feed the `updateStack
 			niteoawsCF = niteoaws.cloudFormationProvider.factory @data.region
 
 			content = grunt.option(@data.templateKey)
-			name = @data.name
+			data = @data
 
 			if not content?
 				grunt.fail.fatal "The template retreived was invalid."
@@ -289,13 +289,13 @@ This example uses the output from the `processTemplate` to feed the `updateStack
 						done()
 					, (err) ->
 						if err.message == "No updates are to be performed."
-							niteoawsCF.getStackId(name)
+							niteoawsCF.getStackId(data.name)
 								.then (result) =>
 									grunt.log.ok "Successfully retreived the stack id #{result}"
 									niteoawsCF.getResource(result)
 								.done (result) =>
 									grunt.verbose.writeln JSON.stringify(result, null, 4)['gray']
-									grunt.option(@data.outputKey, result)
+									grunt.option(data.outputKey, result)
 									grunt.log.ok "Successfully retreived the stack metadata and placed it into grunt.option(#{@data.outputKey})"
 									grunt.log.writeln err
 						else 

--- a/lib/awscloudformation.litcoffee
+++ b/lib/awscloudformation.litcoffee
@@ -288,7 +288,7 @@ This example uses the output from the `processTemplate` to feed the `updateStack
 						grunt.log.ok "Successfully retreived the stack metadata and placed it into grunt.option(#{@data.outputKey})"
 						done()
 					, (err) ->
-						grunt.fail.fatal err
+						if err.message == "No updates are to be performed." then grunt.fail.warn err else grunt.fail.fatal err
 						done()
 					, (progress) ->
 						grunt.log.writeln "#{moment().format()}: #{progress}"['gray']

--- a/lib/awscloudformation.litcoffee
+++ b/lib/awscloudformation.litcoffee
@@ -288,7 +288,7 @@ This example uses the output from the `processTemplate` to feed the `updateStack
 						grunt.log.ok "Successfully retreived the stack metadata and placed it into grunt.option(#{@data.outputKey})"
 						done()
 					, (err) ->
-						if err.message == "No updates are to be performed." then grunt.fail.warn err else grunt.fail.fatal err
+						if err.message == "No updates are to be performed." then grunt.log.warn err else grunt.fail.fatal err
 						done()
 					, (progress) ->
 						grunt.log.writeln "#{moment().format()}: #{progress}"['gray']

--- a/lib/awscloudformation.litcoffee
+++ b/lib/awscloudformation.litcoffee
@@ -258,6 +258,7 @@ This example uses the output from the `processTemplate` to feed the `updateStack
 			niteoawsCF = niteoaws.cloudFormationProvider.factory @data.region
 
 			content = grunt.option(@data.templateKey)
+			name = @data.name
 
 			if not content?
 				grunt.fail.fatal "The template retreived was invalid."
@@ -268,7 +269,6 @@ This example uses the output from the `processTemplate` to feed the `updateStack
 				.then (result) =>
 					if not result
 						grunt.fail.fatal "Stack #{@data.name} does not exist."
-						return
 					else
 						grunt.log.ok "Stack #{@data.name} exists and can be updated."
 						niteoawsCF.validateTemplate(content)
@@ -279,7 +279,7 @@ This example uses the output from the `processTemplate` to feed the `updateStack
 								grunt.log.ok "Successfully updated stack #{@data.name}"
 				.then =>
 					niteoawsCF.getStackId(@data.name)
-				.then (result)=>
+				.then (result) =>
 					grunt.log.ok "Successfully retreived the stack id #{result}"
 					niteoawsCF.getResource(result)
 				.done (result) =>
@@ -289,7 +289,7 @@ This example uses the output from the `processTemplate` to feed the `updateStack
 						done()
 					, (err) ->
 						if err.message == "No updates are to be performed."
-							niteoawsCF.getStackId(@data.name)
+							niteoawsCF.getStackId(name)
 								.then (result) =>
 									grunt.log.ok "Successfully retreived the stack id #{result}"
 									niteoawsCF.getResource(result)

--- a/lib/awscloudformation.litcoffee
+++ b/lib/awscloudformation.litcoffee
@@ -360,4 +360,5 @@ Grunt Task Registrations
 
 		grunt.registerMultiTask 'processTemplate', grunt.niteo.aws.cloudFormation.processTemplate
 		grunt.registerMultiTask 'createStack', grunt.niteo.aws.cloudFormation.createStack
+		grunt.registerMultiTask 'updateStack', grunt.niteo.aws.cloudFormation.updateStack
 		grunt.registerMultiTask 'deleteStack', grunt.niteo.aws.cloudFormation.deleteStack

--- a/lib/awscloudformation.litcoffee
+++ b/lib/awscloudformation.litcoffee
@@ -288,7 +288,18 @@ This example uses the output from the `processTemplate` to feed the `updateStack
 						grunt.log.ok "Successfully retreived the stack metadata and placed it into grunt.option(#{@data.outputKey})"
 						done()
 					, (err) ->
-						if err.message == "No updates are to be performed." then grunt.log.writeln err else grunt.fail.fatal err
+						if err.message == "No updates are to be performed."
+							niteoawsCF.getStackId(@data.name)
+								.then (result) =>
+									grunt.log.ok "Successfully retreived the stack id #{result}"
+									niteoawsCF.getResource(result)
+								.done (result) =>
+									grunt.verbose.writeln JSON.stringify(result, null, 4)['gray']
+									grunt.option(@data.outputKey, result)
+									grunt.log.ok "Successfully retreived the stack metadata and placed it into grunt.option(#{@data.outputKey})"
+									grunt.log.writeln err
+						else 
+							grunt.fail.fatal err
 						done()
 					, (progress) ->
 						grunt.log.writeln "#{moment().format()}: #{progress}"['gray']

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "colors": "^1.0.3",
     "lodash": "^2.4.1",
     "moment": "^2.8.4",
-    "niteoaws": "git://github.com/ToneD/niteoaws.git#capabilities",
+    "niteoaws": "^0.0",
     "q": "^1.1.2",
     "string": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "colors": "^1.0.3",
     "lodash": "^2.4.1",
     "moment": "^2.8.4",
-    "niteoaws": "^0.0",
+    "niteoaws": "git://github.com/ToneD/niteoaws.git#updateStack",
     "q": "^1.1.2",
     "string": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "colors": "^1.0.3",
     "lodash": "^2.4.1",
     "moment": "^2.8.4",
-    "niteoaws": "git://github.com/ToneD/niteoaws.git#updateStack",
+    "niteoaws": "^0.0",
     "q": "^1.1.2",
     "string": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "colors": "^1.0.3",
     "lodash": "^2.4.1",
     "moment": "^2.8.4",
-    "niteoaws": "^0.0",
+    "niteoaws": "git://github.com/ToneD/niteoaws.git#capabilities",
     "q": "^1.1.2",
     "string": "^3.0.0"
   }

--- a/tests/awscloudformation.tests.coffee
+++ b/tests/awscloudformation.tests.coffee
@@ -11,32 +11,32 @@ cloudFormationProviderStub = null
 
 getGruntStub = ->
 	log:
-		writeln: sinon.stub() 
+		writeln: sinon.stub()
 		ok: sinon.stub()  #console.log
-		error: sinon.stub() 
+		error: sinon.stub()
 	verbose:
-		writeln: sinon.stub() 
-		ok: sinon.stub() 
+		writeln: sinon.stub()
+		ok: sinon.stub()
 	fail:
-		warn: sinon.stub() 
-		fatal: sinon.stub() 
-	fatal: sinon.stub() 
-	warn: sinon.stub() 
+		warn: sinon.stub()
+		fatal: sinon.stub()
+	fatal: sinon.stub()
+	warn: sinon.stub()
 	_options: { }
 	option: (key, value) ->
 		if value?
 			@_options[key] = value
 		else
 			@_options[key]
-	registerTask: sinon.stub() 
-	registerMultiTask: sinon.stub() 
+	registerTask: sinon.stub()
+	registerMultiTask: sinon.stub()
 	task:
-		run: sinon.stub() 
-		clearQueue: sinon.stub() 
+		run: sinon.stub()
+		clearQueue: sinon.stub()
 	template:
-		process: sinon.stub() 
+		process: sinon.stub()
 	file:
-		read: sinon.stub() 
+		read: sinon.stub()
 
 getThisPointer = ->
 	data: { }
@@ -53,12 +53,12 @@ beforeEachMethod = ->
 	grunt = getGruntStub()
 	loadGrunt(grunt)
 
-	thisPointer = 
+	thisPointer =
 		data: { }
 		async: ->
 			return ->
 
-	cloudFormationProviderStub = 
+	cloudFormationProviderStub =
 		getResource: sinon.stub().returns Q(true)
 		getResources: sinon.stub().returns Q(true)
 		validateTemplate: sinon.stub().returns Q(true)
@@ -76,7 +76,7 @@ beforeEachMethod = ->
 describe 'grunt', ->
 
 	beforeEach beforeEachMethod
-	
+
 	describe 'niteo', ->
 
 		it 'should define the grunt.niteo namespace when it does not already exist.', ->
@@ -86,7 +86,7 @@ describe 'grunt', ->
 		it 'should not overwrite the grunt.niteo namespace if it is already defined.', ->
 
 			grunt = getGruntStub()
-			grunt.niteo = 
+			grunt.niteo =
 				SomeOtherObject: { }
 
 			loadGrunt(grunt)
@@ -103,7 +103,7 @@ describe 'grunt', ->
 			it 'should not overwrite the grunt.niteo.aws namespace if it is already defined.', ->
 
 				grunt = getGruntStub()
-				grunt.niteo = 
+				grunt.niteo =
 					aws:
 						SomeOtherObject: { }
 
@@ -121,7 +121,7 @@ describe 'grunt', ->
 				it 'should not overwrite the grunt.niteo.aws.cloudFormation namespace if it is already defined.', ->
 
 					grunt = getGruntStub()
-					grunt.niteo = 
+					grunt.niteo =
 						aws:
 							cloudFormation:
 								SomeOtherObject: { }
@@ -210,7 +210,7 @@ describe 'grunt', ->
 
 						thisPointer.data.key = ""
 						thisPointer.data.src = ""
-						thisPointer.data.data = 
+						thisPointer.data.data =
 							HelloProperty: "Hello"
 
 						grunt.file.read.returns "Some Content"
@@ -219,7 +219,7 @@ describe 'grunt', ->
 						grunt.niteo.aws.cloudFormation.processTemplate.call(thisPointer)
 
 						grunt.template.process.calledOnce.should.be.true
-						grunt.template.process.alwaysCalledWithExactly("Some Content", 
+						grunt.template.process.alwaysCalledWithExactly("Some Content",
 							data:
 								HelloProperty: "Hello"
 						)
@@ -233,7 +233,7 @@ describe 'grunt', ->
 						grunt.niteo.aws.cloudFormation.processTemplate.call(thisPointer)
 
 						grunt._options["Hi"].should.equal "Some Value"
-						
+
 					it 'should call createJSONStringArray if @data.convertToArray is true.', ->
 
 						thisPointer.data.key = "Hi!"
@@ -293,7 +293,7 @@ describe 'grunt', ->
 								done()
 
 						grunt.niteo.aws.cloudFormation.createStack.call(thisPointer)
-						
+
 					it 'should call grunt.warn and return if @data.name is null.', (done) ->
 
 						called = false
@@ -307,7 +307,7 @@ describe 'grunt', ->
 								done()
 
 						grunt.niteo.aws.cloudFormation.createStack.call(thisPointer)
-						
+
 					it 'should call grunt.warn and return if @data.templateKey is undefined.', (done) ->
 
 						called = false
@@ -321,13 +321,13 @@ describe 'grunt', ->
 								done()
 
 						grunt.niteo.aws.cloudFormation.createStack.call(thisPointer)
-						
+
 					it 'should call grunt.warn and return if @data.templateKey is null.', (done) ->
 
 						called = false
 						thisPointer.data.region = ""
-						thisPointer.data.name = "" 
-						thisPointer.data.templateKey = null 
+						thisPointer.data.name = ""
+						thisPointer.data.templateKey = null
 						thisPointer.data.outputKey = ""
 						thisPointer.async = ->
 							return ->
@@ -335,12 +335,12 @@ describe 'grunt', ->
 								done()
 
 						grunt.niteo.aws.cloudFormation.createStack.call(thisPointer)
-						
+
 					it 'should call grunt.warn and return if @data.outputKey is undefined.', (done) ->
 
 						called = false
 						thisPointer.data.region = ""
-						thisPointer.data.name = "" 
+						thisPointer.data.name = ""
 						thisPointer.data.templateKey = ""
 						#thisPointer.data.outputKey = ""
 						thisPointer.async = ->
@@ -349,12 +349,12 @@ describe 'grunt', ->
 								done()
 
 						grunt.niteo.aws.cloudFormation.createStack.call(thisPointer)
-						
+
 					it 'should call grunt.warn and return if @data.outputKey is null.', (done) ->
 
 						called = false
 						thisPointer.data.region = ""
-						thisPointer.data.name = "" 
+						thisPointer.data.name = ""
 						thisPointer.data.templateKey = ""
 						thisPointer.data.outputKey = null
 						thisPointer.async = ->
@@ -366,7 +366,7 @@ describe 'grunt', ->
 
 					it 'should create new cloud formation provider with given region.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: 'Some Region'
 								name: ""
@@ -374,7 +374,7 @@ describe 'grunt', ->
 								outputKey: ""
 							async: ->
 								return ->
-									cloudFormationProviderFactoryStub.calledOnce.should.be.true					
+									cloudFormationProviderFactoryStub.calledOnce.should.be.true
 									cloudFormationProviderFactoryStub.alwaysCalledWithExactly 'Some Region'
 									done()
 
@@ -382,7 +382,7 @@ describe 'grunt', ->
 
 					it 'should call grunt.fail.fatal if the value at grunt.option("@data.templateKey") is undefined.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: ""
@@ -397,7 +397,7 @@ describe 'grunt', ->
 
 					it 'should call grunt.fail.fatal if the value at grunt.option("@data.templateKey") is null.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: ""
@@ -413,7 +413,7 @@ describe 'grunt', ->
 
 					it 'should call doesStackExist with the name of the stack.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -421,17 +421,17 @@ describe 'grunt', ->
 								outputKey: ""
 							async: ->
 								return ->
-									cloudFormationProviderStub.doesStackExist.calledOnce.should.be.true					
+									cloudFormationProviderStub.doesStackExist.calledOnce.should.be.true
 									cloudFormationProviderStub.doesStackExist.alwaysCalledWithExactly(thisPointer.data.name).should.be.true
 									done()
-						
+
 						grunt.option(thisPointer.data.templateKey, "Some Content")
 
 						grunt.niteo.aws.cloudFormation.createStack.call(thisPointer)
 
 					it 'should call grunt.fail.fatal if doesStackExist errors', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -450,7 +450,7 @@ describe 'grunt', ->
 
 					it 'should call validateTemplate with template content if stack does not exist.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -458,7 +458,7 @@ describe 'grunt', ->
 								outputKey: "Some OutputKey"
 							async: ->
 								return ->
-									cloudFormationProviderStub.validateTemplate.calledOnce.should.be.true					
+									cloudFormationProviderStub.validateTemplate.calledOnce.should.be.true
 									cloudFormationProviderStub.validateTemplate.alwaysCalledWithExactly("Some Content").should.be.true
 									done()
 
@@ -470,7 +470,7 @@ describe 'grunt', ->
 
 					it 'should call grunt.fail.fatal if validateTemplate errors and if stack does not exist.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -491,7 +491,7 @@ describe 'grunt', ->
 
 					it 'should call createStack with @data.name and template content if stack does not exist.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -501,7 +501,7 @@ describe 'grunt', ->
 								capabilities: "Some Capabilities"
 							async: ->
 								return ->
-									cloudFormationProviderStub.createStack.calledOnce.should.be.true					
+									cloudFormationProviderStub.createStack.calledOnce.should.be.true
 									cloudFormationProviderStub.createStack.alwaysCalledWithExactly("Some Name", "Some Content", "Some Parameters", "Some Capabilities").should.be.true
 									done()
 
@@ -513,7 +513,7 @@ describe 'grunt', ->
 
 					it 'should call grunt.fail.fatal if createStack fails and template content if stack does not exist.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -535,7 +535,7 @@ describe 'grunt', ->
 
 					it 'should call getStackId with @data.name.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -543,8 +543,8 @@ describe 'grunt', ->
 								outputKey: "Some OutputKey"
 								parameters: "Some Parameters"
 							async: ->
-								return ->	
-									cloudFormationProviderStub.getStackId.calledOnce.should.be.true					
+								return ->
+									cloudFormationProviderStub.getStackId.calledOnce.should.be.true
 									cloudFormationProviderStub.getStackId.alwaysCalledWithExactly("Some Name").should.be.true
 									done()
 
@@ -556,7 +556,7 @@ describe 'grunt', ->
 
 					it 'should call grunt.fail.fatal if getStackId fails.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -577,7 +577,7 @@ describe 'grunt', ->
 
 					it 'should call getResource with result of getStackId.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -586,7 +586,7 @@ describe 'grunt', ->
 								parameters: "Some Parameters"
 							async: ->
 								return ->
-									cloudFormationProviderStub.getResource.calledOnce.should.be.true					
+									cloudFormationProviderStub.getResource.calledOnce.should.be.true
 									cloudFormationProviderStub.getResource.alwaysCalledWithExactly("Stack Id").should.be.true
 									done()
 
@@ -598,7 +598,7 @@ describe 'grunt', ->
 
 					it 'should call grunt.fail.fatal if getResource fails.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -619,7 +619,7 @@ describe 'grunt', ->
 
 					it 'should place the result of getResource into grunt.option(@data.outputKey)', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -680,7 +680,7 @@ describe 'grunt', ->
 								done()
 
 						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
-						
+
 					it 'should call grunt.warn and return if @data.name is null.', (done) ->
 
 						called = false
@@ -694,7 +694,7 @@ describe 'grunt', ->
 								done()
 
 						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
-						
+
 					it 'should call grunt.warn and return if @data.templateKey is undefined.', (done) ->
 
 						called = false
@@ -708,13 +708,13 @@ describe 'grunt', ->
 								done()
 
 						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
-						
+
 					it 'should call grunt.warn and return if @data.templateKey is null.', (done) ->
 
 						called = false
 						thisPointer.data.region = ""
-						thisPointer.data.name = "" 
-						thisPointer.data.templateKey = null 
+						thisPointer.data.name = ""
+						thisPointer.data.templateKey = null
 						thisPointer.data.outputKey = ""
 						thisPointer.async = ->
 							return ->
@@ -722,12 +722,12 @@ describe 'grunt', ->
 								done()
 
 						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
-						
+
 					it 'should call grunt.warn and return if @data.outputKey is undefined.', (done) ->
 
 						called = false
 						thisPointer.data.region = ""
-						thisPointer.data.name = "" 
+						thisPointer.data.name = ""
 						thisPointer.data.templateKey = ""
 						#thisPointer.data.outputKey = ""
 						thisPointer.async = ->
@@ -736,12 +736,12 @@ describe 'grunt', ->
 								done()
 
 						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
-						
+
 					it 'should call grunt.warn and return if @data.outputKey is null.', (done) ->
 
 						called = false
 						thisPointer.data.region = ""
-						thisPointer.data.name = "" 
+						thisPointer.data.name = ""
 						thisPointer.data.templateKey = ""
 						thisPointer.data.outputKey = null
 						thisPointer.async = ->
@@ -753,7 +753,7 @@ describe 'grunt', ->
 
 					it 'should create new cloud formation provider with given region.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: 'Some Region'
 								name: ""
@@ -761,7 +761,7 @@ describe 'grunt', ->
 								outputKey: ""
 							async: ->
 								return ->
-									cloudFormationProviderFactoryStub.calledOnce.should.be.true					
+									cloudFormationProviderFactoryStub.calledOnce.should.be.true
 									cloudFormationProviderFactoryStub.alwaysCalledWithExactly 'Some Region'
 									done()
 
@@ -769,7 +769,7 @@ describe 'grunt', ->
 
 					it 'should call grunt.fail.fatal if the value at grunt.option("@data.templateKey") is undefined.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: ""
@@ -784,7 +784,7 @@ describe 'grunt', ->
 
 					it 'should call grunt.fail.fatal if the value at grunt.option("@data.templateKey") is null.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: ""
@@ -800,7 +800,7 @@ describe 'grunt', ->
 
 					it 'should call doesStackExist with the name of the stack.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -808,17 +808,17 @@ describe 'grunt', ->
 								outputKey: ""
 							async: ->
 								return ->
-									cloudFormationProviderStub.doesStackExist.calledOnce.should.be.true					
+									cloudFormationProviderStub.doesStackExist.calledOnce.should.be.true
 									cloudFormationProviderStub.doesStackExist.alwaysCalledWithExactly(thisPointer.data.name).should.be.true
 									done()
-						
+
 						grunt.option(thisPointer.data.templateKey, "Some Content")
 
 						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
 
 					it 'should call grunt.fail.fatal if doesStackExist errors', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -837,7 +837,7 @@ describe 'grunt', ->
 
 					it 'should call grunt.fail.fatal if stack does not exist.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -846,7 +846,7 @@ describe 'grunt', ->
 							async: ->
 								return ->
 									grunt.fail.fatal.calledOnce.should.be.true
-									grunt.fail.fatal.alwaysCalledWithExactly("Stack #{thisPointer.data.name} does not exist.").should.be.true
+									grunt.fail.fatal.alwaysCalledWithExactly("The stack #{thisPointer.data.name} does not exist.").should.be.true
 									done()
 
 						grunt.option(thisPointer.data.templateKey, "Some Content")
@@ -857,7 +857,7 @@ describe 'grunt', ->
 
 					it 'should call grunt.fail.fatal if validateTemplate errors and if stack exists.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -878,7 +878,7 @@ describe 'grunt', ->
 
 					it 'should call updateStack with @data.name and template content if stack exists.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -888,7 +888,7 @@ describe 'grunt', ->
 								capabilities: "Some Capabilities"
 							async: ->
 								return ->
-									cloudFormationProviderStub.updateStack.calledOnce.should.be.true					
+									cloudFormationProviderStub.updateStack.calledOnce.should.be.true
 									cloudFormationProviderStub.updateStack.alwaysCalledWithExactly("Some Name", "Some Content", "Some Parameters", "Some Capabilities").should.be.true
 									done()
 
@@ -900,7 +900,7 @@ describe 'grunt', ->
 
 					it 'should call grunt.fail.fatal if updateStack fails and template content if stack exists.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -922,7 +922,7 @@ describe 'grunt', ->
 
 					it 'should call getStackId with @data.name.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -930,8 +930,8 @@ describe 'grunt', ->
 								outputKey: "Some OutputKey"
 								parameters: "Some Parameters"
 							async: ->
-								return ->	
-									cloudFormationProviderStub.getStackId.calledOnce.should.be.true					
+								return ->
+									cloudFormationProviderStub.getStackId.calledOnce.should.be.true
 									cloudFormationProviderStub.getStackId.alwaysCalledWithExactly("Some Name").should.be.true
 									done()
 
@@ -943,7 +943,7 @@ describe 'grunt', ->
 
 					it 'should call grunt.fail.fatal if getStackId fails.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -964,7 +964,7 @@ describe 'grunt', ->
 
 					it 'should call getResource with result of getStackId.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -973,7 +973,7 @@ describe 'grunt', ->
 								parameters: "Some Parameters"
 							async: ->
 								return ->
-									cloudFormationProviderStub.getResource.calledTwice.should.be.true					
+									cloudFormationProviderStub.getResource.calledOnce.should.be.true
 									cloudFormationProviderStub.getResource.alwaysCalledWithExactly("Stack Id").should.be.true
 									done()
 
@@ -985,7 +985,7 @@ describe 'grunt', ->
 
 					it 'should call grunt.fail.fatal if getResource fails.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -1006,7 +1006,7 @@ describe 'grunt', ->
 
 					it 'should place the result of getResource into grunt.option(@data.outputKey)', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -1038,7 +1038,7 @@ describe 'grunt', ->
 								grunt.fail.fatal.calledOnce.should.be.true
 								done()
 
-						grunt.niteo.aws.cloudFormation.deleteStack.call(thisPointer)	
+						grunt.niteo.aws.cloudFormation.deleteStack.call(thisPointer)
 
 					it 'should call grunt.fail.fatal and return if @data.region is null.', (done) ->
 
@@ -1051,7 +1051,7 @@ describe 'grunt', ->
 								grunt.fail.fatal.calledOnce.should.be.true
 								done()
 
-						grunt.niteo.aws.cloudFormation.deleteStack.call(thisPointer)	
+						grunt.niteo.aws.cloudFormation.deleteStack.call(thisPointer)
 
 					it 'should call grunt.fail.fatal and return if @data.name is undefined.', (done) ->
 
@@ -1077,11 +1077,11 @@ describe 'grunt', ->
 								grunt.fail.fatal.calledOnce.should.be.true
 								done()
 
-						grunt.niteo.aws.cloudFormation.deleteStack.call(thisPointer)			
+						grunt.niteo.aws.cloudFormation.deleteStack.call(thisPointer)
 
 					it 'should create new cloud formation provider with given region.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: 'Some Region'
 								name: ""
@@ -1089,7 +1089,7 @@ describe 'grunt', ->
 								outputKey: ""
 							async: ->
 								return ->
-									cloudFormationProviderFactoryStub.calledOnce.should.be.true					
+									cloudFormationProviderFactoryStub.calledOnce.should.be.true
 									cloudFormationProviderFactoryStub.alwaysCalledWithExactly('Some Region').should.be.true
 									done()
 
@@ -1097,7 +1097,7 @@ describe 'grunt', ->
 
 					it 'should call deleteStack with @data.name.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"
@@ -1106,7 +1106,7 @@ describe 'grunt', ->
 								parameters: "Some Parameters"
 							async: ->
 								return ->
-									cloudFormationProviderStub.deleteStack.calledOnce.should.be.true					
+									cloudFormationProviderStub.deleteStack.calledOnce.should.be.true
 									cloudFormationProviderStub.deleteStack.alwaysCalledWithExactly('Some Name').should.be.true
 									done()
 
@@ -1116,7 +1116,7 @@ describe 'grunt', ->
 
 					it 'should call grunt.fail.fatal if deleteStack fails.', (done) ->
 
-						thisPointer = 
+						thisPointer =
 							data:
 								region: "Some Region"
 								name: "Some Name"

--- a/tests/awscloudformation.tests.coffee
+++ b/tests/awscloudformation.tests.coffee
@@ -638,6 +638,393 @@ describe 'grunt', ->
 
 						grunt.niteo.aws.cloudFormation.createStack.call(thisPointer)
 
+				describe 'updateStack', ->
+
+					it 'should call grunt.warn and return if @data.region is undefined.', (done) ->
+
+						#thisPointer.data.region = ""
+						thisPointer.data.name = ""
+						thisPointer.data.templateKey = ""
+						thisPointer.data.outputKey = ""
+						thisPointer.async = ->
+							return ->
+								grunt.fail.fatal.calledOnce.should.be.true
+								done()
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should call grunt.warn and return if @data.region is null.', (done) ->
+
+						called = false
+						thisPointer.data.region = null
+						thisPointer.data.name = ""
+						thisPointer.data.templateKey = ""
+						thisPointer.data.outputKey = ""
+						thisPointer.async = ->
+							return ->
+								grunt.fail.fatal.calledOnce.should.be.true
+								done()
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should call grunt.warn and return if @data.name is undefined.', (done) ->
+
+						called = false
+						thisPointer.data.region = ""
+						#thisPointer.data.name = ""
+						thisPointer.data.templateKey = ""
+						thisPointer.data.outputKey = ""
+						thisPointer.async = ->
+							return ->
+								grunt.fail.fatal.calledOnce.should.be.true
+								done()
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+						
+					it 'should call grunt.warn and return if @data.name is null.', (done) ->
+
+						called = false
+						thisPointer.data.region = ""
+						thisPointer.data.name = null
+						thisPointer.data.templateKey = ""
+						thisPointer.data.outputKey = ""
+						thisPointer.async = ->
+							return ->
+								grunt.fail.fatal.calledOnce.should.be.true
+								done()
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+						
+					it 'should call grunt.warn and return if @data.templateKey is undefined.', (done) ->
+
+						called = false
+						thisPointer.data.region = ""
+						thisPointer.data.name = ""
+						#thisPointer.data.templateKey = ""
+						thisPointer.data.outputKey = ""
+						thisPointer.async = ->
+							return ->
+								grunt.fail.fatal.calledOnce.should.be.true
+								done()
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+						
+					it 'should call grunt.warn and return if @data.templateKey is null.', (done) ->
+
+						called = false
+						thisPointer.data.region = ""
+						thisPointer.data.name = "" 
+						thisPointer.data.templateKey = null 
+						thisPointer.data.outputKey = ""
+						thisPointer.async = ->
+							return ->
+								grunt.fail.fatal.calledOnce.should.be.true
+								done()
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+						
+					it 'should call grunt.warn and return if @data.outputKey is undefined.', (done) ->
+
+						called = false
+						thisPointer.data.region = ""
+						thisPointer.data.name = "" 
+						thisPointer.data.templateKey = ""
+						#thisPointer.data.outputKey = ""
+						thisPointer.async = ->
+							return ->
+								grunt.fail.fatal.calledOnce.should.be.true
+								done()
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+						
+					it 'should call grunt.warn and return if @data.outputKey is null.', (done) ->
+
+						called = false
+						thisPointer.data.region = ""
+						thisPointer.data.name = "" 
+						thisPointer.data.templateKey = ""
+						thisPointer.data.outputKey = null
+						thisPointer.async = ->
+							return ->
+								grunt.fail.fatal.calledOnce.should.be.true
+								done()
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should create new cloud formation provider with given region.', (done) ->
+
+						thisPointer = 
+							data:
+								region: 'Some Region'
+								name: ""
+								templateKey: ""
+								outputKey: ""
+							async: ->
+								return ->
+									cloudFormationProviderFactoryStub.calledOnce.should.be.true					
+									cloudFormationProviderFactoryStub.alwaysCalledWithExactly 'Some Region'
+									done()
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should call grunt.fail.fatal if the value at grunt.option("@data.templateKey") is undefined.', (done) ->
+
+						thisPointer = 
+							data:
+								region: "Some Region"
+								name: ""
+								templateKey: "Some Key"
+								outputKey: ""
+							async: ->
+								return ->
+									grunt.fail.fatal.calledOnce.should.be.true
+									done()
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should call grunt.fail.fatal if the value at grunt.option("@data.templateKey") is null.', (done) ->
+
+						thisPointer = 
+							data:
+								region: "Some Region"
+								name: ""
+								templateKey: "Some Key"
+								outputKey: ""
+							async: ->
+								return ->
+									grunt.fail.fatal.calledOnce.should.be.true
+									done()
+
+						grunt.option thisPointer.templateKey, null
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should call doesStackExist with the name of the stack.', (done) ->
+
+						thisPointer = 
+							data:
+								region: "Some Region"
+								name: "Some Name"
+								templateKey: "Some Key"
+								outputKey: ""
+							async: ->
+								return ->
+									cloudFormationProviderStub.doesStackExist.calledOnce.should.be.true					
+									cloudFormationProviderStub.doesStackExist.alwaysCalledWithExactly(thisPointer.data.name).should.be.true
+									done()
+						
+						grunt.option(thisPointer.data.templateKey, "Some Content")
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should call grunt.fail.fatal if doesStackExist errors', (done) ->
+
+						thisPointer = 
+							data:
+								region: "Some Region"
+								name: "Some Name"
+								templateKey: "Some Key"
+								outputKey: ""
+							async: ->
+								return ->
+									grunt.fail.fatal.calledOnce.should.be.true
+									grunt.fail.fatal.alwaysCalledWithExactly("Random Failure").should.be.true
+									done()
+
+						grunt.option(thisPointer.data.templateKey, "Some Content")
+						cloudFormationProviderStub.doesStackExist.returns Q.reject("Random Failure")
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should call grunt.fail.fatal if stack does not exist.', (done) ->
+
+						thisPointer = 
+							data:
+								region: "Some Region"
+								name: "Some Name"
+								templateKey: "Some Key"
+								outputKey: "Some OutputKey"
+							async: ->
+								return ->
+									grunt.fail.fatal.calledOnce.should.be.true
+									grunt.fail.fatal.alwaysCalledWithExactly("Stack #{thisPointer.data.name} does not exist.").should.be.true
+									done()
+
+						grunt.option(thisPointer.data.templateKey, "Some Content")
+
+						cloudFormationProviderStub.doesStackExist.returns Q(false)
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should call grunt.fail.fatal if validateTemplate errors and if stack exists.', (done) ->
+
+						thisPointer = 
+							data:
+								region: "Some Region"
+								name: "Some Name"
+								templateKey: "Some Key"
+								outputKey: "Some OutputKey"
+							async: ->
+								return ->
+									grunt.fail.fatal.calledOnce
+									grunt.fail.fatal.alwaysCalledWithExactly("Random Failure").should.be.true
+									done()
+
+						grunt.option(thisPointer.data.templateKey, "Some Content")
+
+						cloudFormationProviderStub.doesStackExist.returns Q(true)
+						cloudFormationProviderStub.validateTemplate.returns Q.reject("Random Failure")
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should call updateStack with @data.name and template content if stack exists.', (done) ->
+
+						thisPointer = 
+							data:
+								region: "Some Region"
+								name: "Some Name"
+								templateKey: "Some Key"
+								outputKey: "Some OutputKey"
+								parameters: "Some Parameters"
+								capabilities: "Some Capabilities"
+							async: ->
+								return ->
+									cloudFormationProviderStub.updateStack.calledOnce.should.be.true					
+									cloudFormationProviderStub.updateStack.alwaysCalledWithExactly("Some Name", "Some Content", "Some Parameters", "Some Capabilities").should.be.true
+									done()
+
+						grunt.option(thisPointer.data.templateKey, "Some Content")
+
+						cloudFormationProviderStub.doesStackExist.returns Q(true)
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should call grunt.fail.fatal if updateStack fails and template content if stack exists.', (done) ->
+
+						thisPointer = 
+							data:
+								region: "Some Region"
+								name: "Some Name"
+								templateKey: "Some Key"
+								outputKey: "Some OutputKey"
+								parameters: "Some Parameters"
+							async: ->
+								return ->
+									grunt.fail.fatal.calledOnce
+									grunt.fail.fatal.alwaysCalledWithExactly("Random Failure").should.be.true
+									done()
+
+						grunt.option(thisPointer.data.templateKey, "Some Content")
+
+						cloudFormationProviderStub.doesStackExist.returns Q(true)
+						cloudFormationProviderStub.updateStack.returns Q.reject("Random Failure")
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should call getStackId with @data.name.', (done) ->
+
+						thisPointer = 
+							data:
+								region: "Some Region"
+								name: "Some Name"
+								templateKey: "Some Key"
+								outputKey: "Some OutputKey"
+								parameters: "Some Parameters"
+							async: ->
+								return ->	
+									cloudFormationProviderStub.getStackId.calledOnce.should.be.true					
+									cloudFormationProviderStub.getStackId.alwaysCalledWithExactly("Some Name").should.be.true
+									done()
+
+						grunt.option(thisPointer.data.templateKey, "Some Content")
+
+						cloudFormationProviderStub.doesStackExist.returns Q(false)
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should call grunt.fail.fatal if getStackId fails.', (done) ->
+
+						thisPointer = 
+							data:
+								region: "Some Region"
+								name: "Some Name"
+								templateKey: "Some Key"
+								outputKey: "Some OutputKey"
+								parameters: "Some Parameters"
+							async: ->
+								return ->
+									grunt.fail.fatal.calledOnce
+									grunt.fail.fatal.alwaysCalledWithExactly("Random Failure").should.be.true
+									done()
+
+						grunt.option(thisPointer.data.templateKey, "Some Content")
+
+						cloudFormationProviderStub.getStackId.returns Q.reject("Random Failure")
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should call getResource with result of getStackId.', (done) ->
+
+						thisPointer = 
+							data:
+								region: "Some Region"
+								name: "Some Name"
+								templateKey: "Some Key"
+								outputKey: "Some OutputKey"
+								parameters: "Some Parameters"
+							async: ->
+								return ->
+									cloudFormationProviderStub.getResource.calledOnce.should.be.true					
+									cloudFormationProviderStub.getResource.alwaysCalledWithExactly("Stack Id").should.be.true
+									done()
+
+						grunt.option(thisPointer.data.templateKey, "Some Content")
+
+						cloudFormationProviderStub.getStackId.returns Q("Stack Id")
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should call grunt.fail.fatal if getResource fails.', (done) ->
+
+						thisPointer = 
+							data:
+								region: "Some Region"
+								name: "Some Name"
+								templateKey: "Some Key"
+								outputKey: "Some OutputKey"
+								parameters: "Some Parameters"
+							async: ->
+								return ->
+									grunt.fail.fatal.calledOnce
+									grunt.fail.fatal.alwaysCalledWithExactly("Random Failure").should.be.true
+									done()
+
+						grunt.option(thisPointer.data.templateKey, "Some Content")
+
+						cloudFormationProviderStub.getResource.returns Q.reject("Random Failure")
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
+					it 'should place the result of getResource into grunt.option(@data.outputKey)', (done) ->
+
+						thisPointer = 
+							data:
+								region: "Some Region"
+								name: "Some Name"
+								templateKey: "Some Key"
+								outputKey: "Some OutputKey"
+								parameters: "Some Parameters"
+
+						thisPointer.async = ->
+							return ->
+								grunt.option(thisPointer.data.outputKey).should.equal "ResourceData"
+								done()
+
+						grunt.option(thisPointer.data.templateKey, "Some Content")
+
+						cloudFormationProviderStub.getResource.returns Q("ResourceData")
+
+						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
 				describe 'deleteStack', ->
 
 					it 'should call grunt.fail.fatal and return if @data.region is undefined.', (done) ->

--- a/tests/awscloudformation.tests.coffee
+++ b/tests/awscloudformation.tests.coffee
@@ -920,6 +920,27 @@ describe 'grunt', ->
 
 						grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
 
+					it 'should succeed if updateStack fails with "No updates are to be performed."', (done) ->
+
+					    thisPointer =
+					        data:
+					            region: "Some Region"
+					            name: "Some Name"
+					            templateKey: "Some Key"
+					            outputKey: "Some OutputKey"
+					            parameters: "Some Parameters"
+					        async: ->
+					            return ->
+					                grunt.fail.fatal.calledOnce.should.be.false
+					                done()
+
+					    grunt.option(thisPointer.data.templateKey, "Some Content")
+
+					    cloudFormationProviderStub.doesStackExist.returns Q(true)
+					    cloudFormationProviderStub.updateStack.returns Q.reject({message: "No updates are to be performed."})
+
+					    grunt.niteo.aws.cloudFormation.updateStack.call(thisPointer)
+
 					it 'should call getStackId with @data.name.', (done) ->
 
 						thisPointer =

--- a/tests/awscloudformation.tests.coffee
+++ b/tests/awscloudformation.tests.coffee
@@ -973,7 +973,7 @@ describe 'grunt', ->
 								parameters: "Some Parameters"
 							async: ->
 								return ->
-									cloudFormationProviderStub.getResource.calledOnce.should.be.true					
+									cloudFormationProviderStub.getResource.calledTwice.should.be.true					
 									cloudFormationProviderStub.getResource.alwaysCalledWithExactly("Stack Id").should.be.true
 									done()
 

--- a/tests/awscloudformation.tests.coffee
+++ b/tests/awscloudformation.tests.coffee
@@ -498,10 +498,11 @@ describe 'grunt', ->
 								templateKey: "Some Key"
 								outputKey: "Some OutputKey"
 								parameters: "Some Parameters"
+								capabilities: "Some Capabilities"
 							async: ->
 								return ->
 									cloudFormationProviderStub.createStack.calledOnce.should.be.true					
-									cloudFormationProviderStub.createStack.alwaysCalledWithExactly("Some Name", "Some Content", "Some Parameters").should.be.true
+									cloudFormationProviderStub.createStack.alwaysCalledWithExactly("Some Name", "Some Content", "Some Parameters", "Some Capabilities").should.be.true
 									done()
 
 						grunt.option(thisPointer.data.templateKey, "Some Content")


### PR DESCRIPTION
Hi,
I found your repo this week it was just what I was looking for. You've done a great implementation.
A lot of my cloud formation templates create roles and profiles which require creating the templates with CAPABILITY_IAM.
I have extended your project to support a capabilities array in the grunt config. This has necessitated some small changes to the niteoaws project also, for which I also have a pull request.
My coffee skills are quite lacking so I haven't messed around too much with your tests. There may be some extra tests needed.
Did some more work. I also needed updateStack functionality so i've implemented this. Replicated and slightly modified all your createStack tests for use with udpateStack.
One thing that might look weird is that I get the stack meta data prior (and after in case of update) to updating the stack. This is because I have a use case where I want to get the outputs of a stack that has 'no updates required' and thus it goes into the error handler which doesn't have scope to this.data. You may know of a better way to do this.

ToneD
